### PR TITLE
Update to nom 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ license = "MIT"
 documentation = "http://richo.psych0tik.net/pcapng-rs/pcapng/"
 
 [dependencies]
-nom = "~0.3.6"
+nom = "~1.0.0"

--- a/examples/producer_errors.rs
+++ b/examples/producer_errors.rs
@@ -3,19 +3,16 @@ extern crate nom;
 extern crate pcapng;
 
 use std::env;
-use nom::{FileProducer,Producer};
+use nom::{FileProducer,Producer,ConsumerState};
 use pcapng::block::parse_block;
 
-named!(printer,
+consumer_from_parser!(Printer<()>,
        chain!(
            block: parse_block ,
            ||{
                println!("{:?}", block);
-               &[]
            }
            ));
-
-pusher!(print, printer);
 
 fn main() {
     let args: Vec<_> = env::args().collect();
@@ -25,6 +22,7 @@ fn main() {
     }
 
     let mut producer = FileProducer::new(&args[1][..], 64).unwrap();
-    println!("Running fileproducer");
-    print(&mut producer);
+    let mut consumer = Printer::new();
+    while let &ConsumerState::Continue(_) = producer.apply(&mut consumer) {
+    }
 }


### PR DESCRIPTION
Hi!

nom 1.0 is here, and comes with a few breaking changes. To help the transition, and to test the beta version before release, I took the liberty to test and upgrade (if needed) your code to the 1.0 version. It should work right away, but if there are still issues, or if the code needs to be updated to your latest master, please let me know!

If you want an explanation of the changes, please take a look at the [upgrading documentation](https://github.com/Geal/nom/wiki/Upgrading-to-nom-1.0).

By the way, could you go to one (or all) of those links and write a few kind words about your experience writing parsers in Rust? It would really help me!
- [nom 1.0 release blogpost](https://www.clever-cloud.com/blog/engineering/2015/11/16/nom-1-0/)
- [Reddit post](https://www.reddit.com/r/rust/comments/3t10f3/nom_just_reached_10_cleaner_parsers_more_generic/)
- [Hacker News post](https://news.ycombinator.com/item?id=10574828)

Thank you for using nom!
