### PR TITLE
Update nom to 1.2.4.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pcapng"
-version = "0.0.3"
+version = "0.0.4"
 authors = ["Richo Healey <richo@psych0tik.net>"]
 
 repository = "https://github.com/richo/pcapng-rs"
@@ -9,4 +9,4 @@ license = "MIT"
 documentation = "http://richo.psych0tik.net/pcapng-rs/pcapng/"
 
 [dependencies]
-nom = "~1.0.0"
+nom = "^1.2.4"

--- a/src/blocks/enhanced_packet.rs
+++ b/src/blocks/enhanced_packet.rs
@@ -50,7 +50,7 @@ named!(enhanced_packet_body<&[u8],EnhancedPacket>,
            // Field to a 32-bit boundary
            data: take!(captured_len as usize) ~
            take!(util::pad_to_32bits(captured_len as usize)) ~
-           options: parse_options? ,
+           options: opt!(complete!(parse_options)),
 
            ||{
                EnhancedPacket {

--- a/src/blocks/interface_description.rs
+++ b/src/blocks/interface_description.rs
@@ -28,7 +28,7 @@ named!(interface_description_body<&[u8],InterfaceDescription>,
            link_type: le_u16 ~
            reserved: le_u16 ~
            snap_len: le_u32 ~
-           options: parse_options? ,
+           options: opt!(complete!(parse_options)),
            ||{
                InterfaceDescription {
                    ty: TY,

--- a/src/blocks/section_header.rs
+++ b/src/blocks/section_header.rs
@@ -33,7 +33,7 @@ named!(section_header_body<&[u8],SectionHeader>,
            major_version: le_u16 ~
            minor_version: le_u16 ~
            _section_length: le_u64 ~
-           options: parse_options?,
+           options: opt!(complete!(parse_options)),
 
            // Can we get the blocks by virtue of knowing how much data we have left here?
            ||{


### PR DESCRIPTION
Hi richo, this PR updates nom to the latest version. I had to make a small change to the way options are parsed as nom can return an Incomplete if it needs more bytes in the middle of parsing options. `complete!` will convert that Incomplete to an Error and in turn opt! will set that there are no options.

See the following bug for details.
https://github.com/Geal/nom/issues/271
