### PR TITLE
Nom 3.0 upgrade

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ license = "MIT"
 documentation = "http://richo.psych0tik.net/pcapng-rs/pcapng/"
 
 [dependencies]
-nom = "^2.0"
+nom = "^3.0"

--- a/examples/producer_errors.rs
+++ b/examples/producer_errors.rs
@@ -3,16 +3,17 @@ extern crate nom;
 extern crate pcapng;
 
 use std::env;
-use nom::{FileProducer,Producer,ConsumerState};
+use nom::{IResult,FileProducer,Producer,ConsumerState};
 use pcapng::block::parse_block;
 
+use std::fmt::Debug;
+pub fn print_block<T: Debug>(input: T) -> IResult<T,()> {
+  println!("{:?}", input);
+  IResult::Done(input, ())
+}
+
 consumer_from_parser!(Printer<()>,
-       chain!(
-           block: parse_block ,
-           ||{
-               println!("{:?}", block);
-           }
-           ));
+                      flat_map!(parse_block, print_block));
 
 fn main() {
     let args: Vec<_> = env::args().collect();

--- a/src/blocks/constants.rs
+++ b/src/blocks/constants.rs
@@ -1,3 +1,5 @@
+#![allow(non_camel_case_types)]
+
 #[repr(C)]
 #[derive(Debug, Eq, PartialEq)]
 pub enum BlockType {

--- a/src/blocks/interface_stats.rs
+++ b/src/blocks/interface_stats.rs
@@ -26,12 +26,12 @@ pub const TY: u32 = BlockType::InterfaceStatistics as u32;
 //    +---------------------------------------------------------------+
 
 named!(interface_stats_body<&[u8], InterfaceStatistics>,
-       chain!(
-           interface_id: le_u32 ~
-           timestamp_high: le_u32 ~
-           timestamp_low: le_u32 ~
-           options: opt!(complete!(parse_options)),
-           ||{
+       do_parse!(
+           interface_id: le_u32 >>
+           timestamp_high: le_u32 >>
+           timestamp_low: le_u32 >>
+           options: opt!(complete!(parse_options)) >>
+           (
                InterfaceStatistics {
                    ty: TY,
                    block_length: 0,
@@ -42,7 +42,7 @@ named!(interface_stats_body<&[u8], InterfaceStatistics>,
                    check_length: 0,
                }
 
-           }
+           )
            )
        );
 


### PR DESCRIPTION
Updates from nom v2.0 to v3.0. The main incompatibility was use of the deprecated chain! macro.

`cargo test` seem to pass afterwards, as does `cargo run --example producer_errors testcases/test001.ntar` with `rustc 1.17.0 (56124baa9 2017-04-24)`.